### PR TITLE
Fix compiler warnings

### DIFF
--- a/cxx/toCxx.cpp
+++ b/cxx/toCxx.cpp
@@ -17,7 +17,7 @@ c_buffer_t toCxx(const Napi::Value& input) {
   else {
     Napi::Error::New(input.Env(), "Invalid input type, expected either Buffer of TypedArray").ThrowAsJavaScriptException();
   }
-  DEBUG_OUTPUT((std::stringstream{} << "size is " << res.second).str().c_str());
+  DEBUG_OUTPUT((std::stringstream{} << "size is " << res.second).str());
   return res;
 }
 

--- a/cxx/transports/pcap/Pcap.cpp
+++ b/cxx/transports/pcap/Pcap.cpp
@@ -39,7 +39,7 @@ Napi::Object PcapDevice::Init(Napi::Env env, Napi::Object exports) {
 }
 
 void CallJs(Napi::Env env, Napi::Function jsCallback, Context* context, pcpp::RawPacket* packet) {
-  DEBUG_OUTPUT((std::stringstream{} << "CallJs: " << (void*)packet->getRawData() << packet->getRawDataLen()).str().c_str());
+  DEBUG_OUTPUT((std::stringstream{} << "CallJs: " << (void*)packet->getRawData() << packet->getRawDataLen()).str());
   if (env != nullptr && jsCallback != nullptr) {
     jsCallback.Call({ js_buffer_t::Copy(env, packet->getRawData(), packet->getRawDataLen()) });
   }


### PR DESCRIPTION
```
Pcap.cpp: In function 'void OverTheWire::Transports::Pcap::CallJs(Napi::Env, Napi::Function, Context*, pcpp::RawPacket*)':
Pcap.cpp:42:121: warning: ignoring return value of 'const _CharT* std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::c_str() const [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]', declared with attribute ‘nodiscard’ [-Wunused-result]
   42 |   DEBUG_OUTPUT((std::stringstream{} << "CallJs: " << (void*)packet->getRawData() << packet->getRawDataLen()).str().c_str());
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
```